### PR TITLE
feat: 홈페이지에 프로젝트 API 연동

### DIFF
--- a/src/api/project/api.ts
+++ b/src/api/project/api.ts
@@ -1,0 +1,26 @@
+import { ProjectCondition } from "@/type/project";
+import instance from "../setup";
+
+/**
+ * @descript 프로젝트 목록 조회
+ */
+export const getProjectList = async (query: ProjectCondition) => {
+  const response = await instance.get("/projects", { params: query });
+  return response.data;
+};
+
+/**
+ * @descript 프로젝트 상세 조회
+ */
+export const getProjectById = async (id: number) => {
+  const response = await instance.get(`/projects/${id}`);
+  return response.data;
+};
+
+/**
+ * @descript 프로젝트 이미지 키워드 조회
+ */
+export const getProjectImageKeywords = async (id: number) => {
+  const response = await instance.get(`/projects/${id}/image-keywords`);
+  return response.data;
+};

--- a/src/api/project/data.ts
+++ b/src/api/project/data.ts
@@ -1,0 +1,18 @@
+// 프로젝트 기본형
+export const defaultProject = {
+  id: 0,
+  title: "",
+  imageUrl: "",
+  description: "",
+  areaSize: 0,
+  type: "",
+  durationWeeks: 0,
+  reviews: "",
+}
+
+export const keywordFilters = [
+  { value: "APART", label: "아파트" },
+  { value: "HOUSE", label: "주택" },
+  { value: "COMMERCIAL", label: "상가" },
+  { value: "NEW", label: "신축" },
+];

--- a/src/app/home/component/keyword-area.tsx
+++ b/src/app/home/component/keyword-area.tsx
@@ -141,34 +141,45 @@ const KeywordSlider = ({
   currentIndex: number;
   handleCardClick?: (id: number) => void;
 }) => {
+  const hasProjects =
+    keywordProjectList.length > 0 && keywordProjectList[0].id > 0;
+
   return (
-    <div className="relative overflow-hidden">
-      <div
-        className="flex transition-transform duration-500 ease-in-out rounded-lg shadow pt-5 pb-7"
-        style={{
-          transform: `translateX(-${
-            (currentIndex / keywordProjectList.length) * 100
-          }%)`,
-          width: `${(keywordProjectList.length / itemsPerSlide) * 100}%`,
-        }}
-      >
-        {keywordProjectList.map((project, idx) => (
+    <>
+      {hasProjects ? (
+        <div className="relative overflow-hidden">
           <div
-            key={`project_${idx}`}
-            className="flex-shrink-0 cursor-pointer"
-            style={{ width: `${100 / keywordProjectList.length}%` }}
+            className="flex transition-transform duration-500 ease-in-out rounded-lg shadow pt-5 pb-7"
+            style={{
+              transform: `translateX(-${
+                (currentIndex / keywordProjectList.length) * 100
+              }%)`,
+              width: `${(keywordProjectList.length / itemsPerSlide) * 100}%`,
+            }}
           >
-            <div className="px-5">
-              <KeywordCard
-                project={project}
-                idx={idx}
-                handleCardClick={handleCardClick}
-              />
-            </div>
+            {keywordProjectList.map((project, idx) => (
+              <div
+                key={`project_${idx}`}
+                className="flex-shrink-0 cursor-pointer"
+                style={{ width: `${100 / keywordProjectList.length}%` }}
+              >
+                <div className="px-5">
+                  <KeywordCard
+                    project={project}
+                    idx={idx}
+                    handleCardClick={handleCardClick}
+                  />
+                </div>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
-    </div>
+        </div>
+      ) : (
+        <div className="flex items-center justify-center min-h-[300px] text-center py-8">
+          <p className="text-lg text-gray-500">등록된 시공사례가 없습니다.</p>
+        </div>
+      )}
+    </>
   );
 };
 
@@ -247,7 +258,9 @@ const KeywordControls = ({
               ? "bg-[#E5E7EB]  text-black cursor-not-allowed"
               : "hover:bg-[#111827] hover:text-white "
           }`}
-          disabled={currentIndex === 0}
+          disabled={
+            currentIndex === 0 || keywordProjectList.length <= itemsPerSlide
+          }
         >
           <PrevArrowIcon />
         </Button>
@@ -260,7 +273,10 @@ const KeywordControls = ({
               ? "bg-[#E5E7EB]  text-black cursor-not-allowed"
               : "hover:bg-[#111827] hover:text-white "
           }`}
-          disabled={currentIndex > maxIndex}
+          disabled={
+            currentIndex > maxIndex ||
+            keywordProjectList.length <= itemsPerSlide
+          }
         >
           <NextArrowIcon />
         </Button>

--- a/src/app/home/component/keyword-area.tsx
+++ b/src/app/home/component/keyword-area.tsx
@@ -1,41 +1,58 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { projectsItems } from "@/api/data";
 import { NextArrowIcon, PrevArrowIcon } from "@/component/Icon";
 import { Button } from "@/component/button";
-import { project } from "@/type/project";
+import { Keyword, Project } from "@/type/project";
+import { defaultProject, keywordFilters } from "@/api/project/data";
+import { getProjectList } from "@/api/project/api";
 
 export const KeywordArea = () => {
+  const ITEMS_PER_SLIDE = 4; // 한 번에 보여줄 카드 수
   const router = useRouter();
-  const totalSlides = projectsItems.length;
-  const itemsPerSlide = 4; // 한 번에 보여줄 카드 수
-  const maxIndex = Math.max(0, totalSlides - itemsPerSlide);
+  const totalSlidesRef = useRef(0);
+  const maxIndexRef = useRef(0);
 
-  const filteredItems = [
-    { value: "apt", label: "아파트" },
-    { value: "house", label: "주택" },
-    { value: "mercantile", label: "상가" },
-    { value: "new", label: "신축" },
-  ];
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [selectedCategory, setSelectedCategory] = useState(
-    filteredItems[0].value
+  const [selectedKeyword, setSelectedKeyword] = useState(
+    keywordFilters[0].value
   );
+  const [keywordProjectList, setKeywordProjectList] = useState([
+    defaultProject,
+  ]);
 
-  const nextSlide = () => {
-    setCurrentIndex((prev) => {
-      const nextIndex = prev + 1;
-      return nextIndex > maxIndex ? 0 : nextIndex;
-    });
-  };
+  useEffect(() => {
+    const FetchData = async () => {
+      const fetchData = await getProjectList({
+        page: 1,
+        size: 12,
+        keyword: selectedKeyword.toUpperCase() as Keyword,
+      });
+      const projectData = fetchData.data;
+      const projectList = projectData.list || [];
+      totalSlidesRef.current = projectData.totalCount;
+      maxIndexRef.current = Math.max(
+        0,
+        totalSlidesRef.current - ITEMS_PER_SLIDE
+      );
+      setKeywordProjectList(projectList);
+    };
+    FetchData();
+  }, [selectedKeyword]);
 
   const prevSlide = () => {
     setCurrentIndex((prev) => {
       const prevIndex = prev - 1;
-      return prevIndex < 0 ? maxIndex : prevIndex;
+      return prevIndex < 0 ? maxIndexRef.current : prevIndex;
+    });
+  };
+
+  const nextSlide = () => {
+    setCurrentIndex((prev) => {
+      const nextIndex = prev + 1;
+      return nextIndex > maxIndexRef.current ? 0 : nextIndex;
     });
   };
 
@@ -46,22 +63,24 @@ export const KeywordArea = () => {
   return (
     <div className="px-15 py-10 mx-auto mb-10">
       <KeywordHeader
-        filteredItems={filteredItems}
-        selectedCategory={selectedCategory}
-        onCategoryChange={setSelectedCategory}
+        filteredItems={keywordFilters}
+        selectedKeyword={selectedKeyword}
+        onKeywordChange={setSelectedKeyword}
       />
       <KeywordSlider
+        keywordProjectList={keywordProjectList}
         currentIndex={currentIndex}
-        itemsPerSlide={itemsPerSlide}
+        itemsPerSlide={ITEMS_PER_SLIDE}
         handleCardClick={handleCardClick}
       />
       <div className="container mx-auto px-4">
         <KeywordControls
+          keywordProjectList={keywordProjectList}
           currentIndex={currentIndex}
-          maxIndex={maxIndex}
+          maxIndex={maxIndexRef.current}
           onNext={nextSlide}
           onPrev={prevSlide}
-          itemsPerSlide={itemsPerSlide}
+          itemsPerSlide={ITEMS_PER_SLIDE}
         />
         <div className="flex justify-center mt-10">
           <Button
@@ -80,12 +99,12 @@ export const KeywordArea = () => {
 
 const KeywordHeader = ({
   filteredItems,
-  selectedCategory,
-  onCategoryChange,
+  selectedKeyword,
+  onKeywordChange,
 }: {
   filteredItems: { value: string; label: string }[];
-  selectedCategory: string;
-  onCategoryChange: (value: string) => void;
+  selectedKeyword: string;
+  onKeywordChange: (value: string) => void;
 }) => {
   return (
     <div className="flex justify-between items-center mb-8 px-7">
@@ -95,9 +114,9 @@ const KeywordHeader = ({
           {filteredItems.map((item) => (
             <Button
               key={item.value}
-              onClick={() => onCategoryChange(item.value)}
+              onClick={() => onKeywordChange(item.value)}
               className={`px-4 py-2 rounded ${
-                selectedCategory === item.value
+                selectedKeyword === item.value
                   ? "bg-[#111827] text-white "
                   : "bg-[#E5E7EB] text-gray-800"
               } transition-colors cursor-pointer`}
@@ -112,13 +131,15 @@ const KeywordHeader = ({
 };
 
 const KeywordSlider = ({
-  handleCardClick,
-  currentIndex,
+  keywordProjectList,
   itemsPerSlide,
+  currentIndex,
+  handleCardClick,
 }: {
-  handleCardClick?: (id: number) => void;
-  currentIndex: number;
+  keywordProjectList: Project[];
   itemsPerSlide: number;
+  currentIndex: number;
+  handleCardClick?: (id: number) => void;
 }) => {
   return (
     <div className="relative overflow-hidden">
@@ -126,16 +147,16 @@ const KeywordSlider = ({
         className="flex transition-transform duration-500 ease-in-out rounded-lg shadow pt-5 pb-7"
         style={{
           transform: `translateX(-${
-            (currentIndex / projectsItems.length) * 100
+            (currentIndex / keywordProjectList.length) * 100
           }%)`,
-          width: `${(projectsItems.length / itemsPerSlide) * 100}%`,
+          width: `${(keywordProjectList.length / itemsPerSlide) * 100}%`,
         }}
       >
-        {projectsItems.map((project, idx) => (
+        {keywordProjectList.map((project, idx) => (
           <div
             key={`project_${idx}`}
             className="flex-shrink-0 cursor-pointer"
-            style={{ width: `${100 / projectsItems.length}%` }}
+            style={{ width: `${100 / keywordProjectList.length}%` }}
           >
             <div className="px-5">
               <KeywordCard
@@ -157,7 +178,7 @@ const KeywordCard = ({
   handleCardClick,
 }: {
   idx: number;
-  project: project;
+  project: Project;
   handleCardClick?: (id: number) => void;
 }) => {
   return (
@@ -175,9 +196,7 @@ const KeywordCard = ({
       />
       <div className="p-4">
         <h3 className="font-bold text-lg mb-1">{project.title}</h3>
-        <p className="text-gray-600 text-sm mb-2">
-          {project.durationWeeks}주 소요
-        </p>
+        <p className="text-gray-600 text-sm mb-2">{project.duration}주 소요</p>
         <p className="text-gray-600 text-sm mb-2 text-ellipsis overflow-hidden whitespace-nowrap h-5">
           {project.description}
         </p>
@@ -187,12 +206,14 @@ const KeywordCard = ({
 };
 
 const KeywordControls = ({
+  keywordProjectList,
   currentIndex,
   maxIndex,
   onNext,
   onPrev,
   itemsPerSlide,
 }: {
+  keywordProjectList: Project[];
   currentIndex: number;
   maxIndex: number;
   onNext: () => void;
@@ -200,8 +221,8 @@ const KeywordControls = ({
   itemsPerSlide: number;
 }) => {
   // 기본 4에서 시작해서 인덱스마다 증가
-  const baseProgress = (itemsPerSlide / projectsItems.length) * 100; // 기본 4개 항목에 대한 진행률
-  const indexProgress = (currentIndex / projectsItems.length) * 100; // 현재 인덱스에 따른 추가 진행률
+  const baseProgress = (itemsPerSlide / keywordProjectList.length) * 100; // 기본 4개 항목에 대한 진행률
+  const indexProgress = (currentIndex / keywordProjectList.length) * 100; // 현재 인덱스에 따른 추가 진행률
   const progressPercentage = Math.min(baseProgress + indexProgress, 100);
 
   return (

--- a/src/app/home/component/project-area.tsx
+++ b/src/app/home/component/project-area.tsx
@@ -5,9 +5,11 @@ import { ProjectList } from "@/app/project/component/list";
 import { RightArrowIcon } from "@/component/Icon";
 import { useRouter } from "next/navigation";
 import { Button } from "@/component/button";
+import { Project } from "@/type/project";
 
-export const ProjectArea = () => {
+export const ProjectArea = ({ projectList }: { projectList: Project[] }) => {
   const router = useRouter();
+
   return (
     <div className="py-10 px-20 mb-10 flex flex-col gap-8">
       <div className="flex justify-between items-center mb-4 px-4">
@@ -16,7 +18,7 @@ export const ProjectArea = () => {
           <RightArrowIcon />
         </Link>
       </div>
-      <ProjectList />
+      <ProjectList projectList={projectList} />
       <div className="flex justify-center mt-10">
         <Button
           onClick={() => router.push("/project")}

--- a/src/app/home/component/project-area.tsx
+++ b/src/app/home/component/project-area.tsx
@@ -11,7 +11,7 @@ export const ProjectArea = ({ projectList }: { projectList: Project[] }) => {
   const router = useRouter();
 
   return (
-    <div className="py-10 px-20 mb-10 flex flex-col gap-8">
+    <div className="py-10 px-20 mb-10 flex flex-col gap-8 ">
       <div className="flex justify-between items-center mb-4 px-4">
         <h2 className="text-3xl font-bold">시공사례 프로젝트</h2>
         <Link href={"/project"}>

--- a/src/app/home/component/slide-area.tsx
+++ b/src/app/home/component/slide-area.tsx
@@ -3,17 +3,17 @@
 import { useEffect, useState, useRef } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { projectsItems } from "@/api/data";
+// import { projectsItems } from "@/api/data";
 import { NextArrowIcon, PrevArrowIcon } from "@/component/Icon";
 import { Button } from "@/component/button";
+import { Project } from "@/type/project";
 
-export const SlideArea = () => {
-  // api 호출해서 목록으로 가져오기
-  const images = projectsItems.map(
+export const SlideArea = ({ projectList }: { projectList: Project[] }) => {
+  const images = projectList.map(
     (item) => item.imageUrl || "/image/default-image.png"
   );
   // 무한 슬라이드를 위해 앞뒤에 더미 이미지 추가
-  const slideImages = [images[projectsItems.length - 1], ...images, images[0]];
+  const slideImages = [images[projectList.length - 1], ...images, images[0]];
   const duration = 10000; // 20초
   const router = useRouter();
 
@@ -213,7 +213,7 @@ export const SlideArea = () => {
           // 실제 이미지 인덱스 계산 (더미 제외)
           const realIdx = getRealIndex(idx);
           const isActive = current === idx;
-          const currentImage = projectsItems[realIdx];
+          const currentImage = projectList[realIdx];
 
           return (
             <div

--- a/src/app/home/component/slide-area.tsx
+++ b/src/app/home/component/slide-area.tsx
@@ -9,13 +9,14 @@ import { Button } from "@/component/button";
 import { Project } from "@/type/project";
 
 export const SlideArea = ({ projectList }: { projectList: Project[] }) => {
+  const router = useRouter();
   const images = projectList.map(
     (item) => item.imageUrl || "/image/default-image.png"
   );
+  const DURATION = 10000; // 20초
   // 무한 슬라이드를 위해 앞뒤에 더미 이미지 추가
   const slideImages = [images[projectList.length - 1], ...images, images[0]];
-  const duration = 10000; // 20초
-  const router = useRouter();
+  const hasProjects = projectList.length > 0 && projectList[0].id > 0;
 
   const [current, setCurrent] = useState(1); // 실제 첫 이미지 인덱스는 1
   const [isTransition, setIsTransition] = useState(true);
@@ -25,22 +26,23 @@ export const SlideArea = ({ projectList }: { projectList: Project[] }) => {
   useEffect(() => {
     const timer = setTimeout(() => {
       goToNext();
-    }, duration);
+    }, DURATION);
 
     return () => clearTimeout(timer);
   }, [current]);
 
   // 진행 바 애니메이션
   const startRef = useRef<number | null>(null);
+
   useEffect(() => {
     let frame: number;
     startRef.current = performance.now();
     const animate = (now: number) => {
       if (startRef.current === null) return;
       const elapsed = now - startRef.current;
-      const newProgress = Math.min((elapsed / duration) * 100, 100);
+      const newProgress = Math.min((elapsed / DURATION) * 100, 100);
       setProgress(newProgress);
-      if (elapsed < duration) {
+      if (elapsed < DURATION) {
         frame = requestAnimationFrame(animate);
       }
     };
@@ -132,180 +134,205 @@ export const SlideArea = ({ projectList }: { projectList: Project[] }) => {
   };
 
   return (
-    <div
-      style={{
-        position: "relative",
-        width: "100vw",
-        height: "calc(100vh - 64px)",
-        overflow: "hidden",
-        display: "flex",
-        marginBottom: 22,
-      }}
-    >
-      {/* 이전/다음 버튼 */}
-      <Button
-        onClick={goToPrev}
-        style={{
-          position: "absolute",
-          left: 40,
-          top: "50%",
-          zIndex: 30,
-          transform: "translateY(-50%)",
-          background: "none",
-          color: "#fff",
-          border: "none",
-          borderRadius: 0,
-          width: 56,
-          height: 56,
-          fontSize: 96,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          fontWeight: 700,
-          cursor: "pointer",
-          transition: "color 0.2s",
-        }}
-        aria-label="이전"
-      >
-        <PrevArrowIcon width={56} height={56} />
-      </Button>
-      <Button
-        onClick={goToNext}
-        style={{
-          position: "absolute",
-          right: 40,
-          top: "50%",
-          zIndex: 30,
-          transform: "translateY(-50%)",
-          background: "none",
-          color: "#fff",
-          border: "none",
-          borderRadius: 0,
-          width: 56,
-          height: 56,
-          fontSize: 96,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          fontWeight: 700,
-          cursor: "pointer",
-          transition: "color 0.2s",
-        }}
-        aria-label="다음"
-      >
-        <NextArrowIcon width={56} height={56} />
-      </Button>
+    <>
+      {hasProjects ? (
+        <div
+          style={{
+            position: "relative",
+            width: "100vw",
+            height: "calc(100vh - 64px)",
+            overflow: "hidden",
+            display: "flex",
+            marginBottom: 22,
+          }}
+        >
+          {/* 이전/다음 버튼 */}
+          <Button
+            onClick={goToPrev}
+            style={{
+              position: "absolute",
+              left: 40,
+              top: "50%",
+              zIndex: 30,
+              transform: "translateY(-50%)",
+              background: "none",
+              color: "#fff",
+              border: "none",
+              borderRadius: 0,
+              width: 56,
+              height: 56,
+              fontSize: 96,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontWeight: 700,
+              cursor: "pointer",
+              transition: "color 0.2s",
+            }}
+            aria-label="이전"
+          >
+            <PrevArrowIcon width={56} height={56} />
+          </Button>
+          <Button
+            onClick={goToNext}
+            style={{
+              position: "absolute",
+              right: 40,
+              top: "50%",
+              zIndex: 30,
+              transform: "translateY(-50%)",
+              background: "none",
+              color: "#fff",
+              border: "none",
+              borderRadius: 0,
+              width: 56,
+              height: 56,
+              fontSize: 96,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontWeight: 700,
+              cursor: "pointer",
+              transition: "color 0.2s",
+            }}
+            aria-label="다음"
+          >
+            <NextArrowIcon width={56} height={56} />
+          </Button>
 
-      {/* 슬라이드 컨테이너 */}
-      <div
-        className="flex"
-        style={{
-          width: `${slideImages.length * 100}vw`,
-          height: "calc(100vh - 64px)",
-          transform: `translateX(-${current * 100}vw)`,
-          transition: isTransition
-            ? "transform 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94)"
-            : "none",
-        }}
-        onTransitionEnd={handleTransitionEnd}
-      >
-        {slideImages.map((img, idx) => {
-          // 실제 이미지 인덱스 계산 (더미 제외)
-          const realIdx = getRealIndex(idx);
-          const isActive = current === idx;
-          const currentImage = projectList[realIdx];
+          {/* 슬라이드 컨테이너 */}
+          <div
+            className="flex"
+            style={{
+              width: `${slideImages.length * 100}vw`,
+              height: "calc(100vh - 64px)",
+              transform: `translateX(-${current * 100}vw)`,
+              transition: isTransition
+                ? "transform 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94)"
+                : "none",
+            }}
+            onTransitionEnd={handleTransitionEnd}
+          >
+            {slideImages.map((img, idx) => {
+              // 실제 이미지 인덱스 계산 (더미 제외)
+              const realIdx = getRealIndex(idx);
+              const isActive = current === idx;
+              const currentImage = projectList[realIdx];
 
-          return (
-            <div
-              key={idx}
-              style={{
-                width: "100vw",
-                height: "calc(100vh - 64px)",
-                position: "relative",
-                flexShrink: 0,
-              }}
-            >
-              <Image
-                src={img}
-                alt={`사례 이미지 ${realIdx + 1}`}
-                fill
-                style={{ objectFit: "cover", objectPosition: "center" }}
-                priority={idx === 1}
-              />
-              {isActive && current > 0 && current < slideImages.length - 1 && (
-                <>
-                  {/* 이미지 제목과 설명 */}
-                  <div
-                    style={{
-                      position: "absolute",
-                      left: 200,
-                      bottom: 200,
-                      color: "#fff",
-                      zIndex: 10,
-                    }}
-                  >
-                    <p
-                      style={{
-                        fontSize: "28px",
-                        fontWeight: 500,
-                        lineHeight: 1.5,
-                        textShadow: "1px 1px 2px rgba(0,0,0,0.5)",
-                        opacity: 0.9,
-                      }}
-                    >
-                      {currentImage.description}
-                    </p>
-                    <h2
-                      style={{
-                        fontSize: "56px",
-                        fontWeight: 700,
-                        marginBottom: "8px",
-                        textShadow: "1px 1px 2px rgba(0,0,0,0.5)",
-                      }}
-                    >
-                      {currentImage.title}
-                    </h2>
-                    <Button
-                      onClick={() => {
-                        router.push(`/project/${currentImage.id}`);
-                      }}
-                      style={{ fontSize: "22px", fontWeight: 500 }}
-                    >
-                      자세히 보기
-                    </Button>
-                  </div>
-                  {/* 진행 바 (실제 이미지에서만 표시) */}
-                  <div
-                    style={{
-                      position: "absolute",
-                      left: "50%",
-                      bottom: 70,
-                      transform: "translateX(-50%)",
-                      width: "85vw",
-                      maxWidth: "90%",
-                      height: 8,
-                      background: "rgba(255,255,255,0.25)",
-                      borderRadius: 4,
-                      zIndex: 10,
-                      overflow: "hidden",
-                    }}
-                  >
-                    <div
-                      style={{
-                        height: "100%",
-                        width: `${Math.max(0, Math.min(progress, 100))}%`,
-                        background: progress > 0 ? "#F9F9F9" : "transparent",
-                        borderRadius: 4,
-                        transition: "width 0.1s linear",
-                      }}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
-          );
-        })}
-      </div>
-    </div>
+              return (
+                <div
+                  key={idx}
+                  style={{
+                    width: "100vw",
+                    height: "calc(100vh - 64px)",
+                    position: "relative",
+                    flexShrink: 0,
+                  }}
+                >
+                  <Image
+                    src={img}
+                    alt={`사례 이미지 ${realIdx + 1}`}
+                    fill
+                    style={{ objectFit: "cover", objectPosition: "center" }}
+                    priority={idx === 1}
+                  />
+                  {isActive &&
+                    current > 0 &&
+                    current < slideImages.length - 1 && (
+                      <>
+                        {/* 이미지 제목과 설명 */}
+                        <div
+                          style={{
+                            position: "absolute",
+                            left: 200,
+                            bottom: 200,
+                            color: "#fff",
+                            zIndex: 10,
+                          }}
+                        >
+                          <p
+                            style={{
+                              fontSize: "28px",
+                              fontWeight: 500,
+                              lineHeight: 1.5,
+                              textShadow: "1px 1px 2px rgba(0,0,0,0.5)",
+                              opacity: 0.9,
+                            }}
+                          >
+                            {currentImage.description}
+                          </p>
+                          <h2
+                            style={{
+                              fontSize: "56px",
+                              fontWeight: 700,
+                              marginBottom: "8px",
+                              textShadow: "1px 1px 2px rgba(0,0,0,0.5)",
+                            }}
+                          >
+                            {currentImage.title}
+                          </h2>
+                          <Button
+                            onClick={() => {
+                              router.push(`/project/${currentImage.id}`);
+                            }}
+                            style={{ fontSize: "22px", fontWeight: 500 }}
+                          >
+                            자세히 보기
+                          </Button>
+                        </div>
+                        {/* 진행 바 (실제 이미지에서만 표시) */}
+                        <div
+                          style={{
+                            position: "absolute",
+                            left: "50%",
+                            bottom: 70,
+                            transform: "translateX(-50%)",
+                            width: "85vw",
+                            maxWidth: "90%",
+                            height: 8,
+                            background: "rgba(255,255,255,0.25)",
+                            borderRadius: 4,
+                            zIndex: 10,
+                            overflow: "hidden",
+                          }}
+                        >
+                          <div
+                            style={{
+                              height: "100%",
+                              width: `${Math.max(0, Math.min(progress, 100))}%`,
+                              background:
+                                progress > 0 ? "#F9F9F9" : "transparent",
+                              borderRadius: 4,
+                              transition: "width 0.1s linear",
+                            }}
+                          />
+                        </div>
+                      </>
+                    )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : (
+        <div
+          style={{
+            position: "relative",
+            width: "100vw",
+            height: "calc(100vh - 64px)",
+            overflow: "hidden",
+            marginBottom: 22,
+          }}
+        >
+          <Image
+            src="/image/default-image.png" // 기본 대문 이미지 경로
+            alt="대문 이미지"
+            fill
+            style={{ objectFit: "cover", objectPosition: "center" }}
+            priority
+          />
+        </div>
+      )}
+    </>
   );
 };

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -2,14 +2,19 @@ import { ConsultationArea } from "@/app/home/component/consultation-area";
 import { KeywordArea } from "@/app/home/component/keyword-area";
 import { SlideArea } from "@/app/home/component/slide-area";
 import { ProjectArea } from "./component/project-area";
+import { getProjectList } from "@/api/project/api";
 
-const Home = () => {
+const Home = async () => {
+  const fetchData = await getProjectList({ page: 1, size: 10 });
+  const projectData = fetchData.data;
+  const projectList = projectData.list || [];
+
   return (
     <div className="w-full h-[calc(100vh - 82px)] overflow-x-hidden overflow-y-auto">
       {/* 슬라이드 영역 */}
-      <SlideArea />
+      <SlideArea projectList={projectList} />
       {/* 시공사례 목록 영역 */}
-      <ProjectArea />
+      <ProjectArea projectList={projectList} />
       {/* 키워드 프로젝트 목록 영역 */}
       <KeywordArea />
       {/* 상담신청 영역 */}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -5,7 +5,7 @@ import { ProjectArea } from "./component/project-area";
 import { getProjectList } from "@/api/project/api";
 
 const Home = async () => {
-  const fetchData = await getProjectList({ page: 1, size: 10 });
+  const fetchData = await getProjectList({ page: 1, size: 12 });
   const projectData = fetchData.data;
   const projectList = projectData.list || [];
 

--- a/src/app/project/component/card.tsx
+++ b/src/app/project/component/card.tsx
@@ -1,42 +1,37 @@
-import { project } from "@/type/project";
+import { Project } from "@/type/project";
 import Image from "next/image";
 import Link from "next/link";
 
-export const ProjectCard = ({
-  id,
-  title,
-  imageUrl,
-  description,
-  areaSize,
-  type,
-  durationWeeks,
-}: project) => {
+export const ProjectCard = ({ projectList }: { projectList: Project }) => {
   return (
     <Link
-      href={`/project/${id}`}
+      href={`/project/${projectList.id}`}
       className="bg-white rounded-lg shadow overflow-hidden flex flex-col min-h-[300px]"
     >
       <div className="relative">
-        {type && (
+        {projectList.type && (
           <span className="absolute top-2 left-2 bg-black text-white text-xs font-bold px-2 py-0.5 areaSize-1 rounded z-10">
-            {type}
+            {projectList.type}
           </span>
         )}
         <Image
           width={400}
           height={300}
-          src={imageUrl || ""}
-          alt={title}
+          src={projectList.imageUrl || "/image/default-image.png"}
+          alt={projectList.title}
           className="w-full h-48 object-cover"
         />
       </div>
       <div className="p-4 flex flex-col gap-1 flex-1">
         <h4 className="font-semibold text-lg">
-          {title} <span className="text-xs align-top">{areaSize}py</span>
+          {projectList.title}{" "}
+          <span className="text-xs align-top">{projectList.size}py</span>
         </h4>
-        <div className="text-sm text-gray-500">{durationWeeks}주 소요</div>
+        <div className="text-sm text-gray-500">
+          {projectList.duration}주 소요
+        </div>
         <div className="text-sm text-gray-500 text-ellipsis overflow-hidden whitespace-nowrap h-5">
-          {description}
+          {projectList.description}
         </div>
       </div>
     </Link>

--- a/src/app/project/component/list.tsx
+++ b/src/app/project/component/list.tsx
@@ -1,11 +1,11 @@
-import { projectsItems } from "@/api/data";
 import { ProjectCard } from "./card";
+import { Project } from "@/type/project";
 
-export const ProjectList = () => {
+export const ProjectList = ({ projectList }: { projectList: Project[] }) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      {projectsItems.map((p) => (
-        <ProjectCard key={p.id} {...p} />
+      {projectList.map((project) => (
+        <ProjectCard key={project.id} projectList={project} />
       ))}
     </div>
   );

--- a/src/app/project/component/list.tsx
+++ b/src/app/project/component/list.tsx
@@ -2,11 +2,20 @@ import { ProjectCard } from "./card";
 import { Project } from "@/type/project";
 
 export const ProjectList = ({ projectList }: { projectList: Project[] }) => {
+  const hasProjects = projectList.length > 0 && projectList[0].id > 0;
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      {projectList.map((project) => (
-        <ProjectCard key={project.id} projectList={project} />
-      ))}
-    </div>
+    <>
+      {hasProjects ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {projectList.map((project) => (
+            <ProjectCard key={project.id} projectList={project} />
+          ))}
+        </div>
+      ) : (
+        <div className="flex items-center justify-center min-h-[300px] text-center py-8">
+          <p className="text-lg text-gray-500">등록된 시공사례가 없습니다.</p>
+        </div>
+      )}
+    </>
   );
 };

--- a/src/type/project.ts
+++ b/src/type/project.ts
@@ -1,12 +1,21 @@
-export type project = {
+export type Project = {
   id: number;
   title: string;
-  imageUrl: string | null;
-  description: string | null;
-  areaSize: number;
-  type: string;
-  durationWeeks: number | null;
-  reviews: string | null;
+  imageUrl?: string | null;
+  description?: string | null;
+  size?: number;
+  type?: string;
+  duration?: number | null;
+  reviews?: string | null;
+}
+
+export type ProjectCondition = {
+  page: number;
+  size?: number;
+  search?: string;
+  category?: Category;
+  keyword?: Keyword;
+  lineup?: Lineup;
 }
 
 export type KeywordFilterProps = {
@@ -16,13 +25,13 @@ export type KeywordFilterProps = {
 }
 
 export type ProjectDetailPageProps = {
-  project: project;
+  project: Project;
   keywordFilterProps: KeywordFilterProps;
 }
 
 export type ProjectGalleryProps = {
   selectedView: "card" | "list";
-  imageList: project[];
+  imageList: Project[];
 }
 
 export type GalleryItem = {
@@ -35,4 +44,22 @@ export type GalleryItem = {
 export type ViewButtonProps = {
   selectedView: "card" | "list";
   setSelectedView: (view: "card" | "list") => void;
+}
+
+export enum Category {
+  RESIDENCE = 'RESIDENCE',
+  MERCANTILE = 'MERCANTILE',
+  ARCHITECTURE = 'ARCHITECTURE',
+}
+
+export enum Lineup {
+  FULL = 'FULL',
+  PARTIAL = 'PARTIAL',
+}
+
+export enum Keyword {
+  APART = 'APART',
+  HOUSE = 'HOUSE',
+  COMMERCIAL = 'COMMERCIAL',
+  NEW = 'NEW'
 }


### PR DESCRIPTION
## 🎯 목적
- 시공사례 목록을 조회하는 API를 구현하고, 프론트엔드에서 해당 데이터를 활용하기 위해 필요한 구조와 컴포넌트를 통합

## 📌 변경 사항
- 프로젝트 목록 조회 API 추가 (GET /projects)
- 프로젝트 데이터 구조 정의 및 타입 추가
- 기존 컴포넌트와 통합하여 정보 표시 UI 구현
- 상태 관리 및 API 연동 로직 추가

## 💡 기대 효과
- 홈페이지에서 다양한 프로젝트 정보 출력

## 🧪 테스트 방법
1. 로컬 서버 실행
2. 홈페이지 접속

## 🔗 관련 이슈
- Closes #79 

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 추가/수정
- [ ] 불필요한 코드/로그 제거
