### PR TITLE
feat: API 에러 핸들링 및 글로벌 에러 처리 추가

### DIFF
--- a/src/api/setup.ts
+++ b/src/api/setup.ts
@@ -1,12 +1,15 @@
-import axios from "axios";
+import axios from 'axios';
+import { setupApiInterceptors } from '@/utils/api-error-handler';
 
-const BASE_URL = process.env.BASE_URL || "http://localhost:3001";
-const instance = axios.create({
-  baseURL: BASE_URL,
+const apiClient = axios.create({
+  baseURL: process.env.BASE_URL || 'http://localhost:3001',
+  timeout: 10000,
   headers: {
-    "Content-Type": "application/json",
-    "Accept": "application/json",
+    'Content-Type': 'application/json',
   },
-})
+});
 
-export default instance;
+// API 에러 인터셉터 설정
+setupApiInterceptors(apiClient);
+
+export default apiClient;

--- a/src/api/setup.ts
+++ b/src/api/setup.ts
@@ -1,7 +1,7 @@
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import { setupApiInterceptors } from '@/utils/api-error-handler';
 
-const apiClient = axios.create({
+const apiClient: AxiosInstance = axios.create({
   baseURL: process.env.BASE_URL || 'http://localhost:3001',
   timeout: 10000,
   headers: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Toolbar } from "@/component/toolbar";
 import { Footer } from "@/component/footer";
 import { Error } from "@/component/error";
 import { CompanyProvider } from "@/context/company-context";
+import ClientLayout from "@/component/client-layout";
 import "../style/global.css";
 
 export const metadata: Metadata = {
@@ -32,11 +33,14 @@ const RootLayout = ({
       <body style={{ fontFamily: "Pretendard, sans-serif" }}>
         <CompanyProvider>
           <Toolbar />
-          {children ? children : <Error status="notfound" />}
+          <ClientLayout>
+            {children ? children : <Error status="notfound" />}
+          </ClientLayout>
           <Footer />
         </CompanyProvider>
       </body>
     </html>
   );
 };
+
 export default RootLayout;

--- a/src/component/client-layout.tsx
+++ b/src/component/client-layout.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import ErrorBoundary from './error-boundary';
+
+interface ClientLayoutProps {
+  children: React.ReactNode;
+}
+
+const ClientLayout = ({ children }: ClientLayoutProps) => {
+  return (
+    <ErrorBoundary>
+      {children}
+    </ErrorBoundary>
+  );
+};
+
+export default ClientLayout;

--- a/src/component/error-boundary.tsx
+++ b/src/component/error-boundary.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+import GlobalErrorHandler from '@/utils/error-handler';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    GlobalErrorHandler.reactErrorHandler(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center min-h-[300px] p-8 text-center">
+          <h2 className="text-xl font-semibold text-red-600 mb-4">
+            문제가 발생했습니다
+          </h2>
+          <p className="text-gray-600 mb-6">
+            페이지를 새로고침해주세요.
+          </p>
+          <button 
+            onClick={() => window.location.reload()}
+            className="bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700"
+          >
+            새로고침
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/component/error-boundary.tsx
+++ b/src/component/error-boundary.tsx
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import React from 'react';
-import GlobalErrorHandler from '@/utils/error-handler';
+import React from "react";
+import GlobalErrorHandler from "@/utils/error-handler";
 
 interface ErrorBoundaryState {
   hasError: boolean;
@@ -11,7 +11,10 @@ interface ErrorBoundaryProps {
   children: React.ReactNode;
 }
 
-class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false };
@@ -28,14 +31,12 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex flex-col items-center justify-center min-h-[300px] p-8 text-center">
-          <h2 className="text-xl font-semibold text-red-600 mb-4">
+        <div className="flex flex-col items-center justify-center min-h-screen p-8 text-center">
+          <h2 className="text-3xl font-semibold text-red-400 mb-4">
             문제가 발생했습니다
           </h2>
-          <p className="text-gray-600 mb-6">
-            페이지를 새로고침해주세요.
-          </p>
-          <button 
+          <p className="text-gray-600 mb-6">페이지를 새로고침해주세요.</p>
+          <button
             onClick={() => window.location.reload()}
             className="bg-blue-600 text-white px-6 py-3 rounded-md hover:bg-blue-700"
           >

--- a/src/component/error.tsx
+++ b/src/component/error.tsx
@@ -23,12 +23,12 @@ export const Error = ({ status }: { status: string }) => {
           >
             홈 화면으로 이동
           </Link>
-          <Link
+          {/* <Link
             href="#"
             className="text-sm font-semibold text-gray-900 dark:text-white"
           >
             지원팀에 문의하기 <span aria-hidden="true">&rarr;</span>
-          </Link>
+          </Link> */}
         </div>
       </div>
     </main>

--- a/src/type/error.ts
+++ b/src/type/error.ts
@@ -57,6 +57,7 @@ export interface ApiError {
   stack?: string;
   response?: {
     status?: number;
+    statusText?: string;
   };
 }
 

--- a/src/type/error.ts
+++ b/src/type/error.ts
@@ -2,16 +2,72 @@ export enum ERROR_CODE {
   NOTFOUND = 404,
   UNAUTHORIZED = 401,
   FORBIDDEN = 403,
+  SERVER = 500,
 }
 
 export enum ERROR_MESSAGES {
   NOTFOUND = "페이지를 찾을 수 없습니다.",
   UNAUTHORIZED = "이 페이지를 볼 수 있는 권한이 없습니다.",
   FORBIDDEN = "접근이 거부되었습니다.",
+  SERVER = "서버 오류가 발생했습니다.",
 }
 
 export enum ERROR_DESCRIPTION {
   NOTFOUND = "요청한 페이지가 서버에 존재하지 않습니다.",
   UNAUTHORIZED = "이 페이지를 볼 수 있는 권한이 없습니다.",
   FORBIDDEN = "접근이 거부되었습니다.",
+  SERVER = "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+}
+
+
+export interface ErrorInfo {
+  type: 'javascript' | 'promise' | 'react' | 'api';
+  message: string;
+  filename?: string;
+  lineno?: number;
+  colno?: number;
+  error?: Error;
+  stack?: string;
+  componentStack?: string;
+  status?: number;
+  statusText?: string;
+  url?: string;
+  method?: string;
+  context?: string;
+}
+
+export interface StructuredError extends ErrorInfo {
+  timestamp: string;
+  userAgent: string;
+  url: string;
+}
+
+export interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+export interface ApiError {
+  message?: string;
+  stack?: string;
+  response?: {
+    status?: number;
+  };
+}
+
+
+export interface AxiosInstance {
+  interceptors: {
+    response: {
+      use: (
+        success: (response: unknown) => unknown,
+        error: (error: unknown) => Promise<never>
+      ) => void;
+    };
+  };
 }

--- a/src/utils/api-error-handler.ts
+++ b/src/utils/api-error-handler.ts
@@ -1,29 +1,54 @@
-import { ApiError, AxiosInstance } from '@/type/error';
+import { AxiosInstance, AxiosError } from 'axios';
 import GlobalErrorHandler from './error-handler';
+import { ApiError } from '@/type/error';
 
-export const handleApiError = (error: ApiError): void => {
+export const handleApiError = (error: AxiosError | ApiError | Error | unknown): void => {
   // 서버 환경에서는 로깅만
   if (typeof window === 'undefined') {
-    console.error('API Error:', error?.message || 'Unknown error');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    console.error('API Error:', errorMessage);
     return;
+  }
+
+  // 에러 정보 추출
+  let message = 'API 요청 중 오류가 발생했습니다';
+  let stack: string | undefined;
+  let status: number | undefined;
+
+  if (error instanceof Error) {
+    message = error.message;
+    stack = error.stack;
+  }
+
+  // Axios 에러인 경우
+  if (error && typeof error === 'object' && 'response' in error) {
+    const axiosError = error as AxiosError;
+    status = axiosError.response?.status;
+  }
+
+  // API 에러 객체인 경우
+  if (error && typeof error === 'object' && 'response' in error) {
+    const apiError = error as ApiError;
+    message = apiError.message || message;
+    stack = apiError.stack;
+    status = apiError.response?.status;
   }
 
   GlobalErrorHandler.handleError({
     type: 'api',
-    message: error?.message || 'API 요청 중 오류가 발생했습니다',
-    stack: error?.stack,
-    status: error?.response?.status
+    message,
+    stack,
+    status
   });
 };
-
 
 export const setupApiInterceptors = (axiosInstance: AxiosInstance): void => {
   if (typeof window === 'undefined') return;
 
   axiosInstance.interceptors.response.use(
-    (response: unknown) => response,
-    (error: unknown) => {
-      handleApiError(error as ApiError);
+    (response) => response,
+    (error: AxiosError) => {
+      handleApiError(error);
       return Promise.reject(error);
     }
   );

--- a/src/utils/api-error-handler.ts
+++ b/src/utils/api-error-handler.ts
@@ -1,0 +1,30 @@
+import { ApiError, AxiosInstance } from '@/type/error';
+import GlobalErrorHandler from './error-handler';
+
+export const handleApiError = (error: ApiError): void => {
+  // 서버 환경에서는 로깅만
+  if (typeof window === 'undefined') {
+    console.error('API Error:', error?.message || 'Unknown error');
+    return;
+  }
+
+  GlobalErrorHandler.handleError({
+    type: 'api',
+    message: error?.message || 'API 요청 중 오류가 발생했습니다',
+    stack: error?.stack,
+    status: error?.response?.status
+  });
+};
+
+
+export const setupApiInterceptors = (axiosInstance: AxiosInstance): void => {
+  if (typeof window === 'undefined') return;
+
+  axiosInstance.interceptors.response.use(
+    (response: unknown) => response,
+    (error: unknown) => {
+      handleApiError(error as ApiError);
+      return Promise.reject(error);
+    }
+  );
+};

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -1,0 +1,63 @@
+import { ErrorInfo } from "@/type/error";
+
+
+class GlobalErrorHandler {
+  private static instance: GlobalErrorHandler | null = null;
+
+  constructor() {
+    if (GlobalErrorHandler.instance) {
+      return GlobalErrorHandler.instance;
+    }
+
+    this.setupGlobalHandlers();
+    GlobalErrorHandler.instance = this;
+  }
+
+  private setupGlobalHandlers(): void {
+    if (typeof window === 'undefined') return;
+
+    // JavaScript 에러
+    window.addEventListener('error', (event) => {
+      this.handleError({
+        type: 'javascript',
+        message: event.message,
+        stack: event.error?.stack,
+        url: event.filename
+      });
+    });
+
+    // Promise rejection 에러
+    window.addEventListener('unhandledrejection', (event) => {
+      this.handleError({
+        type: 'promise',
+        message: event.reason?.message || 'Unhandled Promise Rejection',
+        stack: event.reason?.stack
+      });
+    });
+  }
+
+  public handleError(errorInfo: ErrorInfo): void {
+    console.error('Global Error:', errorInfo);
+
+    // 개발 환경에서만 상세 로그
+    if (process.env.NODE_ENV === 'development') {
+      console.error('Error Details:', {
+        type: errorInfo.type,
+        message: errorInfo.message,
+        stack: errorInfo.stack,
+        timestamp: new Date().toISOString()
+      });
+    }
+  }
+
+  // React 에러 경계용
+  public reactErrorHandler = (error: Error, errorInfo: React.ErrorInfo): void => {
+    this.handleError({
+      type: 'react',
+      message: error.message,
+      stack: error.stack
+    });
+  };
+}
+
+export default new GlobalErrorHandler();


### PR DESCRIPTION
## 🎯 목적
- 네트워크 에러 및 예외 상황 발생 시 일관된 방식으로 사용자에게 안내하고 디버깅을 용이하게 하기 위함

## 📌 변경 사항
- 전역 에러 핸들러 유틸 추가
- api 에러 핸들러 유틸 추가
- rootlayout에 에러 바운드 추가
- setup.ts에 api 에러 핸들러 적용

## 💡 기대 효과
- 에러 발생 시 전역 처리

## 🧪 테스트 방법
- 

## 🔗 관련 이슈
- Closes #90 

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 추가/수정
- [ ] 불필요한 코드/로그 제거
