### PR TITLE
fix: 직영가구 공간안내 사진 추가

### DIFF
--- a/src/app/furniture/detail/component/space.tsx
+++ b/src/app/furniture/detail/component/space.tsx
@@ -23,7 +23,7 @@ export const FurnitureSpace = ({ furniture }: { furniture: Furniture }) => {
                 <Image
                   src={
                     (furniture?.images && furniture?.images[0]) ||
-                    "/image/no-image.png"
+                    "/image/bang.png"
                   }
                   alt="베스트 아이템"
                   fill
@@ -53,7 +53,7 @@ export const FurnitureSpace = ({ furniture }: { furniture: Furniture }) => {
                 <Image
                   src={
                     (furniture?.images && furniture?.images[1]) ||
-                    "/image/no-image.png"
+                    "/image/job.png"
                   }
                   alt="작업 공간 & 제작 현장 소개"
                   fill


### PR DESCRIPTION
<!-- 제목 예시: [FEAT] 계약 목록 페이지네이션 구현 -->

## 🎯 목적
- 직영가구 상세페이지 공간안내에  사진이 없어 사진추가

## 📌 변경 사항
- 직영가구 상세페이지 공간안내 사진추가

## 💡 기대 효과
-

## 🧪 테스트 방법
- 
  
## 🔗 관련 이슈
- Closes #110 

## ✅ 체크리스트
- [ ] 로컬에서 정상 동작 확인
- [ ] 테스트 코드 추가/수정
- [ ] 불필요한 코드/로그 제거
